### PR TITLE
Add setup-jest.cjs

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,4 +2,5 @@ dist/
 lib/
 node_modules/
 jest.config.js
+setup-jest.cjs
 __tests__/

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,5 +5,8 @@ module.exports = {
   transform: {
     '^.+\\.ts$': 'ts-jest'
   },
+  setupFilesAfterEnv: [
+    '<rootDir>/setup-jest.cjs'
+  ],
   verbose: true
 }

--- a/setup-jest.cjs
+++ b/setup-jest.cjs
@@ -1,0 +1,5 @@
+const os = require('os')
+
+beforeAll(() => {
+  process.env.RUNNER_TEMP ??= os.tmpdir()
+})


### PR DESCRIPTION
Since `RUNNER_TEMP` environment variable is assumed to exist,
`npm run test` fails on local machine.

`setup-jest.cjs` adds `beforeAll()` to set `RUNNER_TEMP` if not existing.