### PR TITLE
Remove cache and integration test options

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,8 +57,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./
-        with:
-          install-cli-integration-test: 'true'
+        env:
+          AUTIFY_CLI_INTEGRATION_TEST_INSTALL: 1
       - run: |
           echo token | autify web auth login
           echo token | autify mobile auth login
@@ -66,14 +66,3 @@ jobs:
         env:
           AUTIFY_CONNECT_CLIENT_MODE: fake
       - run: autify-cli-integration-test
-
-  test-use-cache:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./
-        with:
-          use-cache: 'true'
-      - uses: ./
-        with:
-          use-cache: 'true'

--- a/README.md
+++ b/README.md
@@ -27,14 +27,6 @@ shell-installer-url:
   description: "Shell installer URL"
   # TODO: Use stable
   default: "https://autify-cli-assets.s3.amazonaws.com/autify-cli/channels/beta/install-cicd.bash"
-use-cache:
-  required: false
-  description: "Use cached CLI installed by previous steps if existing."
-  default: "false"
-install-cli-integration-test:
-  required: false
-  description: "Install autify-cli-integration-test package as well."
-  default: "false"
 ```
 
 ### v1

--- a/action.yml
+++ b/action.yml
@@ -8,14 +8,6 @@ inputs:
     description: 'Shell installer URL'
     # TODO: Use stable
     default: "https://autify-cli-assets.s3.amazonaws.com/autify-cli/channels/beta/install-cicd.bash"
-  use-cache:
-    required: false
-    description: 'Use cached CLI installed by previous steps if existing.'
-    default: 'false'
-  install-cli-integration-test:
-    required: false
-    description: 'Install autify-cli-integration-test package as well.'
-    default: 'false'
 
 runs:
   using: 'composite'
@@ -26,7 +18,5 @@ runs:
       shell: bash
       env:
         INPUT_SHELL_INSTALLER_URL: ${{ inputs.shell-installer-url }}
-        INPUT_USE_CACHE: ${{ inputs.use-cache }}
-        INPUT_INSTALL_CLI_INTEGRATION_TEST: ${{ inputs.install-cli-integration-test }}
     - run: autify --version
       shell: bash

--- a/script.bash
+++ b/script.bash
@@ -2,17 +2,9 @@
 set -xe
 
 : "${INPUT_SHELL_INSTALLER_URL:?"Provide the installer URL"}"
-: "${INPUT_USE_CACHE:?"Provide true or false"}"
-: "${INPUT_INSTALL_CLI_INTEGRATION_TEST:?"Provide true or false"}"
-
-if [ "$INPUT_USE_CACHE" == "true" ]; then
-  export AUTIFY_CLI_INSTALL_USE_CACHE=1
-fi
-if [ "$INPUT_INSTALL_CLI_INTEGRATION_TEST" == "true" ]; then
-  export AUTIFY_CLI_INTEGRATION_TEST_INSTALL=1
-fi
 
 cd "$RUNNER_TEMP"
+export AUTIFY_CLI_INSTALL_USE_CACHE=1
 curl -L "$INPUT_SHELL_INSTALLER_URL" | bash -xe
 
 cat "$RUNNER_TEMP/autify/path" >> "$GITHUB_PATH"


### PR DESCRIPTION
We change mind that these options are not needed to expose.

This commit enables cache always and let the environment variable decide whether integration test is needed.