### PR TITLE
Add cooldown time for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
<!--
You can see the purpose and details of the following sections on Notion
https://www.notion.so/autifyhq/Pull-Request-Template-03b9d950e70d40ae9a3ea3fc8cd8087b
-->

# JIRA Link

https://autifyhq.atlassian.net/browse/MOB-2864

This patch would add 3 days cooldown for dependabot.

Reference: https://github.blog/changelog/2025-07-01-dependabot-supports-configuration-of-a-minimum-package-age/

# Evidence and Screenshots/Videos (How has this been tested)

We'll see as we go